### PR TITLE
Change how .toJSON() works

### DIFF
--- a/barricade.js
+++ b/barricade.js
@@ -641,6 +641,17 @@ var Barricade = (function () {
         */
         isRequired: function () {
             return this._schema['@required'] !== false;
+        },
+
+        _toJSON: function (options) {
+            var pretty = options && options.pretty;
+            if ( pretty && this._getPrettyJSON ) {
+                return this._getPrettyJSON(options);
+            } else if ( !pretty && this._getJSON ) {
+                return this._getJSON(options);
+            } else {
+                return undefined;
+            }
         }
     }));
 
@@ -945,10 +956,15 @@ var Barricade = (function () {
         * @returns {Array} JSON array containing JSON representations of each
                            element.
         */
-        toJSON: function (ignoreUnused) {
-            return this._data.map(function (el) {
-                return el.toJSON(ignoreUnused);
-            });
+        toJSON: function (options) {
+            var json = this._toJSON(options);
+            if ( json !== undefined ) {
+                return json;
+            } else {
+                return this._data.map(function (el) {
+                    return el.toJSON(options);
+                });
+            }
         }
     });
 
@@ -1091,14 +1107,20 @@ var Barricade = (function () {
         * @returns {Object} JSON representation of the ImmutableObject and its
                    values.
         */
-        toJSON: function (ignoreUnused) {
-            var data = this._data;
-            return this.getKeys().reduce(function (jsonOut, key) {
-                if (ignoreUnused !== true || data[key].isUsed()) {
-                    jsonOut[key] = data[key].toJSON(ignoreUnused);
-                }
-                return jsonOut;
-            }, {});
+        toJSON: function (options) {
+            var data = this._data,
+              json = this._toJSON(options),
+              ignoreUnused = options && options.ignoreUnused;
+            if ( json !== undefined ) {
+                return json;
+            } else {
+                return this.getKeys().reduce(function (jsonOut, key) {
+                    if (ignoreUnused !== true || data[key].isUsed()) {
+                        jsonOut[key] = data[key].toJSON(options);
+                    }
+                    return jsonOut;
+                }, {});
+            }
         }
     });
 
@@ -1205,15 +1227,20 @@ var Barricade = (function () {
         * @returns {Object} JSON object containing JSON representations of each
                    element.
         */
-        toJSON: function (ignoreUnused) {
-            return this.toArray().reduce(function (jsonOut, element) {
+        toJSON: function (options) {
+            var json = this._toJSON(options);
+            if ( json !== undefined ) {
+              return json;
+            } else {
+              return this.toArray().reduce(function (jsonOut, element) {
                 if (jsonOut.hasOwnProperty(element.getID())) {
-                    logError("ID found multiple times: " + element.getID());
+                  logError("ID found multiple times: " + element.getID());
                 } else {
-                    jsonOut[element.getID()] = element.toJSON(ignoreUnused);
+                  jsonOut[element.getID()] = element.toJSON(options);
                 }
                 return jsonOut;
-            }, {});
+              }, {});
+            }
         }
     });
 
@@ -1291,8 +1318,13 @@ var Barricade = (function () {
         * @instance
         * @returns {JSON}
         */
-        toJSON: function () {
-            return this._data;
+        toJSON: function (options) {
+            var json = this._toJSON(options);
+            if ( json !== undefined ) {
+                return json;
+            } else {
+                return this._data;
+            }
         }
     });
 

--- a/src/arraylike.js
+++ b/src/arraylike.js
@@ -182,9 +182,14 @@
         * @returns {Array} JSON array containing JSON representations of each
                            element.
         */
-        toJSON: function (ignoreUnused) {
-            return this._data.map(function (el) {
-                return el.toJSON(ignoreUnused);
-            });
+        toJSON: function (options) {
+            var json = this._toJSON(options);
+            if ( json !== undefined ) {
+                return json;
+            } else {
+                return this._data.map(function (el) {
+                    return el.toJSON(options);
+                });
+            }
         }
     });

--- a/src/base.js
+++ b/src/base.js
@@ -153,5 +153,16 @@
         */
         isRequired: function () {
             return this._schema['@required'] !== false;
+        },
+
+        _toJSON: function (options) {
+            var pretty = options && options.pretty;
+            if ( pretty && this._getPrettyJSON ) {
+                return this._getPrettyJSON(options);
+            } else if ( !pretty && this._getJSON ) {
+                return this._getJSON(options);
+            } else {
+                return undefined;
+            }
         }
     }));

--- a/src/immutable_object.js
+++ b/src/immutable_object.js
@@ -142,13 +142,19 @@
         * @returns {Object} JSON representation of the ImmutableObject and its
                    values.
         */
-        toJSON: function (ignoreUnused) {
-            var data = this._data;
-            return this.getKeys().reduce(function (jsonOut, key) {
-                if (ignoreUnused !== true || data[key].isUsed()) {
-                    jsonOut[key] = data[key].toJSON(ignoreUnused);
-                }
-                return jsonOut;
-            }, {});
+        toJSON: function (options) {
+            var data = this._data,
+              json = this._toJSON(options),
+              ignoreUnused = options && options.ignoreUnused;
+            if ( json !== undefined ) {
+                return json;
+            } else {
+                return this.getKeys().reduce(function (jsonOut, key) {
+                    if (ignoreUnused !== true || data[key].isUsed()) {
+                        jsonOut[key] = data[key].toJSON(options);
+                    }
+                    return jsonOut;
+                }, {});
+            }
         }
     });

--- a/src/mutable_object.js
+++ b/src/mutable_object.js
@@ -115,14 +115,19 @@
         * @returns {Object} JSON object containing JSON representations of each
                    element.
         */
-        toJSON: function (ignoreUnused) {
-            return this.toArray().reduce(function (jsonOut, element) {
+        toJSON: function (options) {
+            var json = this._toJSON(options);
+            if ( json !== undefined ) {
+              return json;
+            } else {
+              return this.toArray().reduce(function (jsonOut, element) {
                 if (jsonOut.hasOwnProperty(element.getID())) {
-                    logError("ID found multiple times: " + element.getID());
+                  logError("ID found multiple times: " + element.getID());
                 } else {
-                    jsonOut[element.getID()] = element.toJSON(ignoreUnused);
+                  jsonOut[element.getID()] = element.toJSON(options);
                 }
                 return jsonOut;
-            }, {});
+              }, {});
+            }
         }
     });

--- a/src/primitive.js
+++ b/src/primitive.js
@@ -86,7 +86,12 @@
         * @instance
         * @returns {JSON}
         */
-        toJSON: function () {
-            return this._data;
+        toJSON: function (options) {
+            var json = this._toJSON(options);
+            if ( json !== undefined ) {
+                return json;
+            } else {
+                return this._data;
+            }
         }
     });

--- a/test/array_spec.js
+++ b/test/array_spec.js
@@ -42,11 +42,19 @@ describe('Arrays', function () {
     beforeEach(function () {
         this.namespace = {};
 
+        this.namespace.CustomString = Barricade.Primitive.extend({
+            _getPrettyJSON: function() {
+                return 'pretty ' + this._data;
+            }
+        }, {
+            '@type': String
+        });
+
         this.namespace.ArrayClass = Barricade.create({
             '@type': Array,
 
             '*': {
-                '@type': String
+                '@class': this.namespace.CustomString
             }
         });
 
@@ -219,7 +227,7 @@ describe('Arrays', function () {
         expect(this.instance1.length()).toBe(3);
     });
 
-    it('.toJSON() should return JSON blob', function () {
+    it('.toJSON() should return raw JSON blob', function () {
         expect(this.instance1.toJSON()).toEqual(['a', 'b', 'c']);
         expect(this.instance2.toJSON()).toEqual([
             'string element 1',
@@ -230,5 +238,20 @@ describe('Arrays', function () {
             'string element 6',
         ]);
         expect(this.instance3.toJSON()).toEqual([]);
+    });
+
+    it('.toJSON({pretty: true}) should return prettified JSON blob',
+      function () {
+        expect(this.instance1.toJSON({pretty: true})).toEqual(
+          ['pretty a', 'pretty b', 'pretty c']);
+        expect(this.instance2.toJSON({pretty: true})).toEqual([
+            'pretty string element 1',
+            'pretty string element 2',
+            'pretty string element 3',
+            'pretty string element 4',
+            'pretty string element 5',
+            'pretty string element 6',
+        ]);
+        expect(this.instance3.toJSON({pretty: true})).toEqual([]);
     });
 });

--- a/test/immutable_object_spec.js
+++ b/test/immutable_object_spec.js
@@ -19,11 +19,19 @@ describe('Immutable Objects', function () {
     beforeEach(function () {
         this.namespace = {};
 
+        this.namespace.CustomString = Barricade.Primitive.extend({
+            _getPrettyJSON: function() {
+                return 'pretty ' + this._data;
+            }
+        }, {
+            '@type': String
+        });
+
         this.namespace.FixedKeyClass = Barricade.create({
             '@type': Object,
 
             'stringKey': {
-                '@type': String
+                '@class': this.namespace.CustomString
             },
             'booleanKey': {
                 '@type': Boolean
@@ -127,9 +135,18 @@ describe('Immutable Objects', function () {
         );
     });
 
-    it('.toJSON() should return JSON blob', function () {
+    it('.toJSON() should return raw JSON blob', function () {
         expect(this.instance.toJSON()).toEqual({
             stringKey: "foo",
+            booleanKey: true,
+            numberKey: 43987
+        });
+    });
+
+    it('.toJSON({pretty: true}) should return prettified JSON blob',
+      function () {
+        expect(this.instance.toJSON({pretty: true})).toEqual({
+            stringKey: "pretty foo",
             booleanKey: true,
             numberKey: 43987
         });

--- a/test/mutable_object_spec.js
+++ b/test/mutable_object_spec.js
@@ -19,11 +19,19 @@ describe('Mutable Objects', function () {
     beforeEach(function () {
         this.namespace = {};
 
+        this.namespace.CustomString = Barricade.Primitive.extend({
+            _getPrettyJSON: function() {
+                return 'pretty ' + this._data;
+            }
+        }, {
+            '@type': String
+        });
+
         this.namespace.WildClass = Barricade.create({
             '@type': Object,
 
             '?': {
-                '@type': String
+                '@class': this.namespace.CustomString
             }
         });
 
@@ -95,11 +103,20 @@ describe('Mutable Objects', function () {
         expect(this.instance.get(3)).toBe(this.instance.get(2));
     });
 
-    it('.toJSON() should return JSON blob', function () {
+    it('.toJSON() should return raw JSON blob', function () {
         expect(this.instance.toJSON()).toEqual({
             foo: "abcd",
             bar: "efgh",
             baz: "ijkl"
+        });
+    });
+
+    it('.toJSON({pretty: true}) should return prettified JSON blob',
+      function () {
+        expect(this.instance.toJSON({pretty: true})).toEqual({
+            foo: "pretty abcd",
+            bar: "pretty efgh",
+            baz: "pretty ijkl"
         });
     });
 

--- a/test/primitive_spec.js
+++ b/test/primitive_spec.js
@@ -163,6 +163,12 @@ describe('Primitives', function () {
             });
         });
 
+        it('.toJSON({pretty: true}) should behave like .toJSON()', function () {
+            types.forEach(function (type) {
+                expect(type.instance.toJSON({pretty: true})).toBe(type.value);
+            });
+        });
+
         it('getPrimitiveType() should return type', function () {
             types.forEach(function (type) {
                 expect(type.instance.getPrimitiveType())


### PR DESCRIPTION
1. Change the single `ignoreUnused` boolean arg to the `options`
object, extract `ignoreUnused = options && options.ignoreUnused` now.

2. Add `pretty` key to options. Like every Python object has 2 methods
string serialization methods (__str__ and __repr__) it is very
convenient to have 2 JSON-serialization modes for every Barricade
object - one for internal purposes (a serialization that can be later
de-serialized, pretty == false), other for purely representation
purposes (no promises on later de-serializing, pretty == true). Each
barricade object can define its own internal/external .toJSON()
implementation in private ._getJSON()/._getPrettyJSON() methods.