### PR TITLE
Add uid() method to Identifiable mixin

### DIFF
--- a/barricade.js
+++ b/barricade.js
@@ -167,42 +167,58 @@ var Barricade = (function () {
     * @mixin
     * @memberof Barricade
     */
-    Identifiable = Blueprint.create(function (id) {
-        /**
-        * Returns the ID
-        * @method getID
-        * @memberof Barricade.Identifiable
-        * @instance
-        * @returns {String}
-        */
-        this.getID = function () {
-            return id;
-        };
+    Identifiable = (function () {
+        var counter = 0;
+        return Blueprint.create(function (id) {
+            var uid = this._uidPrefix + counter++;
 
-        /**
-        * Checks whether the ID is set for this item.
-        * @method hasID
-        * @memberof Barricade.Identifiable
-        * @instance
-        * @returns {Boolean}
-        */
-        this.hasID = function() {
-            return id !== undefined;
-        };
+            /**
+            * Returns the ID
+            * @method getID
+            * @memberof Barricade.Identifiable
+            * @instance
+            * @returns {String}
+            */
+            this.getID = function () {
+                return id;
+            };
 
-        /**
-        * Sets the ID.
-        * @method setID
-        * @memberof Barricade.Identifiable
-        * @instance
-        * @param {String} newID
-        * @returns {self}
-        */
-        this.setID = function (newID) {
-            id = newID;
-            return this.emit('change', 'id');
-        };
+            /**
+            * Gets the unique ID of this particular element
+            * @method uid
+            * @memberof Barricade.Identifiable
+            * @instance
+            * @returns {String}
+            */
+            this.uid = function () {
+                return uid;
+            };
+
+            /**
+            * Checks whether the ID is set for this item.
+            * @method hasID
+            * @memberof Barricade.Identifiable
+            * @instance
+            * @returns {Boolean}
+            */
+            this.hasID = function() {
+                return id !== undefined;
+            };
+
+            /**
+            * Sets the ID.
+            * @method setID
+            * @memberof Barricade.Identifiable
+            * @instance
+            * @param {String} newID
+            * @returns {self}
+            */
+            this.setID = function (newID) {
+                id = newID;
+                return this.emit('change', 'id');
+            };
     });
+})();
 
     /**
     * Tracks whether an object is being "used" or not, which is a state that
@@ -558,6 +574,12 @@ var Barricade = (function () {
 
             return self;
         },
+
+        /**
+        * @memberof Barricade.Base
+        * @private
+        */
+        _uidPrefix: 'obj-',
 
         /**
         * @memberof Barricade.Base

--- a/src/base.js
+++ b/src/base.js
@@ -75,6 +75,12 @@
         * @memberof Barricade.Base
         * @private
         */
+        _uidPrefix: 'obj-',
+
+        /**
+        * @memberof Barricade.Base
+        * @private
+        */
         _getDefaultValue: function () {
             return this._schema.hasOwnProperty('@default')
                 ? typeof this._schema['@default'] === 'function'

--- a/src/mixin/identifiable.js
+++ b/src/mixin/identifiable.js
@@ -19,39 +19,55 @@
     * @mixin
     * @memberof Barricade
     */
-    Identifiable = Blueprint.create(function (id) {
-        /**
-        * Returns the ID
-        * @method getID
-        * @memberof Barricade.Identifiable
-        * @instance
-        * @returns {String}
-        */
-        this.getID = function () {
-            return id;
-        };
+    Identifiable = (function () {
+        var counter = 0;
+        return Blueprint.create(function (id) {
+            var uid = this._uidPrefix + counter++;
 
-        /**
-        * Checks whether the ID is set for this item.
-        * @method hasID
-        * @memberof Barricade.Identifiable
-        * @instance
-        * @returns {Boolean}
-        */
-        this.hasID = function() {
-            return id !== undefined;
-        };
+            /**
+            * Returns the ID
+            * @method getID
+            * @memberof Barricade.Identifiable
+            * @instance
+            * @returns {String}
+            */
+            this.getID = function () {
+                return id;
+            };
 
-        /**
-        * Sets the ID.
-        * @method setID
-        * @memberof Barricade.Identifiable
-        * @instance
-        * @param {String} newID
-        * @returns {self}
-        */
-        this.setID = function (newID) {
-            id = newID;
-            return this.emit('change', 'id');
-        };
+            /**
+            * Gets the unique ID of this particular element
+            * @method uid
+            * @memberof Barricade.Identifiable
+            * @instance
+            * @returns {String}
+            */
+            this.uid = function () {
+                return uid;
+            };
+
+            /**
+            * Checks whether the ID is set for this item.
+            * @method hasID
+            * @memberof Barricade.Identifiable
+            * @instance
+            * @returns {Boolean}
+            */
+            this.hasID = function() {
+                return id !== undefined;
+            };
+
+            /**
+            * Sets the ID.
+            * @method setID
+            * @memberof Barricade.Identifiable
+            * @instance
+            * @param {String} newID
+            * @returns {self}
+            */
+            this.setID = function (newID) {
+                id = newID;
+                return this.emit('change', 'id');
+            };
     });
+})();

--- a/test/mixin/identifiable_spec.js
+++ b/test/mixin/identifiable_spec.js
@@ -32,6 +32,16 @@ describe('Identifiable', function () {
         this.instance = this.namespace
             .ImmutableClass
             .create({a: 42, b: 'some string'});
+
+        this.namespace.outerContainerClass = Barricade.create({
+            '@type': Array,
+            '*': {
+                '@class': this.namespace.ImmutableClass
+            }
+        });
+
+        this.outerContainer = this.namespace.outerContainerClass.create(
+          [this.instance]);
     });
 
     it('is always instance of Identifiable mixin', function () {
@@ -48,5 +58,33 @@ describe('Identifiable', function () {
 
         expect(this.instance.get('a').hasID()).toBe(true);
         expect(this.instance.get('a').getID()).toBe('someNewID');
+    });
+
+    describe('UID properties', function() {
+        it('an arbitrary object has a unique UID', function() {
+            expect(this.instance.uid).toBeDefined();
+            expect(this.instance.uid()).toBeDefined();
+            expect(this.instance.uid()).not.toEqual(
+              this.instance.get('a').uid());
+        });
+
+        it('objects with same contents have different UIDs', function() {
+            var instanceContents = this.instance.toJSON(),
+              secondInstance = this.namespace.ImmutableClass.create(
+                instanceContents);
+
+            expect(this.instance.uid()).not.toEqual(
+              secondInstance.uid());
+        });
+
+        it("changing container's contents doesn't change its UID", function() {
+            var currentContainerHash = this.outerContainer.uid();
+
+            this.outerContainer.push(this.namespace.ImmutableClass.create({
+                'a': 10, 'b': 'some string'}));
+
+            expect(currentContainerHash).toEqual(
+              this.outerContainer.uid());
+        });
     });
 });


### PR DESCRIPTION
.uid() method returns a string representing object's unique
identity, its primary purpose is calculating objects' keys for all
sorts of caching.