### PR TITLE
Fix reference resolving

### DIFF
--- a/barricade.js
+++ b/barricade.js
@@ -263,18 +263,18 @@ var Barricade = (function () {
     */
     Deferrable = Blueprint.create(function (schema) {
         var self = this,
-            deferred;
+            deferred = schema.hasOwnProperty('@ref')
+                ? Deferred.create(schema['@ref'].needs, getter, resolver)
+                : null;
 
-        function resolver(neededValue) {
-            var ref = schema['@ref'].resolver(self, neededValue);
-            if (ref === undefined) {
-                logError('Could not resolve ', JSON.stringify(self.toJSON()));
-            }
-            return ref;
+        function getter(neededValue) {
+            return schema['@ref'].getter(self, neededValue);
         }
 
-        if (schema.hasOwnProperty('@ref')) {
-            deferred = Deferred.create(schema['@ref'].needs, resolver);
+        function resolver(retrievedValue) {
+            self.emit('replace', schema['@ref'].processor
+                                    ? schema['@ref'].processor(retrievedValue)
+                                    : retrievedValue);
         }
 
         this.resolveWith = function (obj) {
@@ -282,7 +282,7 @@ var Barricade = (function () {
 
             if (deferred && !deferred.isResolved()) {
                 if (deferred.needs(obj)) {
-                    this.emit('replace', deferred.resolve(obj));
+                    deferred.resolve(obj);
                 } else {
                     allResolved = false;
                 }
@@ -297,6 +297,10 @@ var Barricade = (function () {
             }
 
             return allResolved;
+        };
+
+        this.isPlaceholder = function () {
+            return !!deferred;
         };
     });
 
@@ -469,10 +473,11 @@ var Barricade = (function () {
                  Callback to execute when resolve happens.
         * @returns {Barricade.Deferred}
         */
-        create: function (classGetter, onResolve) {
+        create: function (classGetter, getter, onResolve) {
             var self = Object.create(this);
             self._isResolved = false;
             self._classGetter = classGetter;
+            self._getter = getter;
             self._onResolve = onResolve;
             return self;
         },
@@ -502,17 +507,25 @@ var Barricade = (function () {
         * @param obj
         */
         resolve: function (obj) {
-            var ref;
+            var self = this,
+                neededValue;
+
+            function doResolve(realNeededValue) {
+                neededValue.off('replace', doResolve);
+                self._onResolve(realNeededValue);
+                self._isResolved = true;
+            }
 
             if (this._isResolved) {
                 throw new Error('Deferred already resolved');
             }
 
-            ref = this._onResolve(obj);
+            neededValue = this._getter(obj);
 
-            if (ref !== undefined) {
-                this._isResolved = true;
-                return ref;
+            if (neededValue.isPlaceholder()) {
+                neededValue.on('replace', doResolve);
+            } else {
+                doResolve(neededValue);
             }
         }
     };

--- a/src/mixin/deferrable.js
+++ b/src/mixin/deferrable.js
@@ -18,18 +18,25 @@
     */
     Deferrable = Blueprint.create(function (schema) {
         var self = this,
+            needed,
             deferred = schema.hasOwnProperty('@ref')
                 ? Deferred.create(schema['@ref'].needs, getter, resolver)
                 : null;
 
-        function getter(neededValue) {
-            return schema['@ref'].getter(self, neededValue);
+        if (schema.hasOwnProperty('@ref') && !schema['@ref'].processor) {
+            schema['@ref'].processor = function (o) { return o.val; };
+        }
+
+        function getter(neededVal) {
+            return schema['@ref'].getter({standIn: self, needed: neededVal});
         }
 
         function resolver(retrievedValue) {
-            self.emit('replace', schema['@ref'].processor
-                                    ? schema['@ref'].processor(retrievedValue)
-                                    : retrievedValue);
+            self.emit('replace', schema['@ref'].processor({
+                val: retrievedValue,
+                standIn: self,
+                needed: needed
+            }));
         }
 
         this.resolveWith = function (obj) {
@@ -37,6 +44,7 @@
 
             if (deferred && !deferred.isResolved()) {
                 if (deferred.needs(obj)) {
+                    needed = obj;
                     deferred.resolve(obj);
                 } else {
                     allResolved = false;

--- a/test/tag/ref_spec.js
+++ b/test/tag/ref_spec.js
@@ -31,15 +31,16 @@ describe('@ref', function () {
                 needs: function () {
                     return self.namespace.Parent;
                 },
-                getter: function (json, parentObj) {
+                getter: function (data) {
                     self.numCalls++;
-                    return parentObj.get('b');
+                    expect(data.standIn.get()).toBe('abc');
+                    return data.needed.get('b');
                 },
-                processor: function (b) {
+                processor: function (data) {
                     self.numProcessorCalls++;
-                    expect(b.instanceof(self.namespace.IsReferredTo))
+                    expect(data.val.instanceof(self.namespace.IsReferredTo))
                         .toBe(true);
-                    return b;
+                    return data.val;
                 }
             }
         });
@@ -51,9 +52,9 @@ describe('@ref', function () {
                 needs: function () {
                     return self.namespace.FluidParent;
                 },
-                getter: function (json, parentObj) {
+                getter: function (data) {
                     self.numCalls++;
-                    return parentObj.get('b');
+                    return data.needed.get('b');
                 }
             }
         });
@@ -65,9 +66,9 @@ describe('@ref', function () {
                 needs: function () {
                     return self.namespace.FluidParent1;
                 },
-                getter: function (json, parentObj) {
+                getter: function (data) {
                     self.numCalls++;
-                    return parentObj.get('b');
+                    return data.needed.get('b');
                 }
             }
         });
@@ -131,8 +132,8 @@ describe('@ref', function () {
                             needs: function () {
                                 return self.namespace.Grandparent;
                             },
-                            getter: function (json, grandparent) {
-                                return grandparent.get('referredTo');
+                            getter: function (data) {
+                                return data.needed.get('referredTo');
                             }
                         }
                     }
@@ -151,8 +152,8 @@ describe('@ref', function () {
                     needs: function () {
                         return self.namespace.Grandparent;
                     },
-                    getter: function (json) {
-                        return self.namespace.Parent2.create(json);
+                    getter: function (data) {
+                        return self.namespace.Parent2.create(data.standIn);
                     }
                 }
             }
@@ -191,9 +192,9 @@ describe('@ref', function () {
                 '@ref': {
                     to: AClass,
                     needs: function () { return ContainerClass; },
-                    getter: function (json, container) {
+                    getter: function (data) {
                         numCalls++;
-                        return container.get('a');
+                        return data.needed.get('a');
                     }
                 }
             }),
@@ -202,7 +203,7 @@ describe('@ref', function () {
                 '@ref': {
                     to: AClass,
                     needs: function () { return ContainerClass; },
-                    getter: function (json, container) {
+                    getter: function (data) {
                         numCalls++;
                         // FIXME(dragorosson): this test relies on the order of
                         // resolving matching the order the keys (a, b, c) are
@@ -213,8 +214,8 @@ describe('@ref', function () {
                         // the placeholder is being retrieved, then resolved,
                         // firing off the resolve of the deferred depending on
                         // this placeholder.
-                        expect(container.get('b').isPlaceholder()).toBe(true);
-                        return container.get('b');
+                        expect(data.needed.get('b').isPlaceholder()).toBe(true);
+                        return data.needed.get('b');
                     }
                 }
             }),


### PR DESCRIPTION
Previously, the user-supplied resolver function did the work of both
getting and (optionally) processing the retrieved value. This
processing was prone to failure if the value retrieved was itself
going to be replaced by a reference (because the processing function
would be expecting a different type of value).

This commit adds the requirement of a 'getter' method used solely to
retrieve the value of interest. Once that value is found (call it X),
it is checked to see if it is a concrete value or a value that will
resolve to a reference (call it R) in the future. If that value needs
resolving, the value which depends on it will not receive the
placeholder value X. Instead, when the real value R is available, that's
what will be sent to the processessing function.